### PR TITLE
Replace deprecated depends_on syntax

### DIFF
--- a/Casks/nothing-bar.rb
+++ b/Casks/nothing-bar.rb
@@ -12,7 +12,7 @@ cask "nothing-bar" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "NothingBar.app"
 


### PR DESCRIPTION
Fix this warning

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :ventura` instead.
Please report this issue to the johnpaulashenfelter/homebrew-tools tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/johnpaulashenfelter/homebrew-tools/Casks/nothing-bar.rb:15
```